### PR TITLE
Fix streamlit cloud deploy error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ geopandas==1.0.1
 pandas==2.2.2
 plotly==5.23.0
 psycopg2==2.9.9
+psycog2-binary==2.9.9
 scipy==1.14.0
 streamlit_folium==0.21.1
 git+https://github.com/josemcorderoc/prompt2map.git@v0.1.1


### PR DESCRIPTION
This pull request fixes a streamlit cloud deploy error by adding `psycopg2-binary` to the requirements.