### PR TITLE
Update psycopg2 to psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ folium==0.17.0
 geopandas==1.0.1
 pandas==2.2.2
 plotly==5.23.0
-psycopg2==2.9.9
 psycopg2-binary==2.9.9
 scipy==1.14.0
 streamlit_folium==0.21.1


### PR DESCRIPTION
This pull request updates the `psycopg2` library to `psycopg2-binary` in the requirements file. This change is made to improve the installation process by using the binary distribution of `psycopg2`.